### PR TITLE
Added PR Preview Teardown

### DIFF
--- a/.github/workflows/pr-teardown.yml
+++ b/.github/workflows/pr-teardown.yml
@@ -1,0 +1,22 @@
+name: Preview Teardown
+
+on:
+  pull_request_target:
+    types: [closed]
+
+jobs:
+  preview-teardown:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Teardown surge preview
+        id: deploy
+        run: npx surge teardown https://quarkusclub-blog-${{ github.event.number }}-preview.surge.sh --token ${{ secrets.SURGE_TOKEN }}
+      - name: Update PR status comment
+        uses: actions-cool/maintain-one-comment@v3.2.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          body: |
+            🙈 The PR is closed and the preview is expired.
+            <!-- Sticky Pull Request Comment -->
+          body-include: '<!-- Sticky Pull Request Comment -->'
+          number: ${{ github.event.number }}


### PR DESCRIPTION
This workflow is triggered when a PR is closed and preview is not longer required.