### PR TITLE
[FIX] Adjustment for PR Preview

### DIFF
--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -2,6 +2,7 @@ name: Build & Preview PR
 
 on:
   pull_request_target:
+    types: [opened, reopened, synchronize]
     paths-ignore:
       - '.gitignore'
       - 'CODEOWNERS'

--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -23,8 +23,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: refs/pull/${{ github.event.number }}/merge
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4

--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -1,7 +1,7 @@
 name: Build & Preview PR
 
 on:
-  pull_request:
+  pull_request_target:
     paths-ignore:
       - '.gitignore'
       - 'CODEOWNERS'
@@ -22,6 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.number }}/merge
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4


### PR DESCRIPTION
An adjustment has been made when PR Preview is triggered, for PR's coming from forks, we should use `pull_request_target` and not `pull_request`.

[Github Docs - Pull Request Target](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request_target)