### PR TITLE
Updated Quarkus Roq Version to 1.5.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
         <quarkus.platform.version>3.22.1</quarkus.platform.version>
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.5.2</surefire-plugin.version>
-        <quarkus.roq.version>1.5.2</quarkus.roq.version>
+        <quarkus.roq.version>1.5.4</quarkus.roq.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Quarkus Roq Version has been updated to 1.5.3

Although 1.5.4 is available, I couldn't downloaded it yet. @mcruzdev could u confirm that?

https://github.com/quarkiverse/quarkus-roq/releases/tag/1.5.4